### PR TITLE
Only set topk webgl flags when using webgl backend

### DIFF
--- a/tfjs-core/src/ops/topk_test.ts
+++ b/tfjs-core/src/ops/topk_test.ts
@@ -27,8 +27,10 @@ import {tensor3d} from './tensor3d';
 describeWithFlags('topk', ALL_ENVS, () => {
   beforeAll(() => {
     // Ensure WebGL environment uses GPU
-    tf.env().set('TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD', 0);
-    tf.env().set('TOPK_K_CPU_HANDOFF_THRESHOLD', 1024);
+    if (tf.getBackend() === 'webgl') {
+      tf.env().set('TOPK_LAST_DIM_CPU_HANDOFF_SIZE_THRESHOLD', 0);
+      tf.env().set('TOPK_K_CPU_HANDOFF_THRESHOLD', 1024);
+    }
   });
 
   it('1d array with k = 0', async () => {


### PR DESCRIPTION
I think this will fix the CI failure.

To see the logs from the Cloud Build CI, please join either our [discussion](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs) or [announcement](https://groups.google.com/a/tensorflow.org/forum/#!forum/tfjs-announce) mailing list.